### PR TITLE
Fix resource dependency.

### DIFF
--- a/configuration/cloudformation/create-cwl-s3-export.template
+++ b/configuration/cloudformation/create-cwl-s3-export.template
@@ -760,7 +760,8 @@
                 }
             },
             "DependsOn": [
-                "CreateLogSourceFunction"
+                "CreateLogSourceFunction",
+                "LambdaDriverExecutionPolicy"
             ]
         },
         "KinesisEventSourceMapping": {


### PR DESCRIPTION
Custom resource was being executed, but there are no policies attached. Fixed to have correct dependency on LambdaDriverExecutionPolicy.