### PR TITLE
Increase timeout on GetCloudWatchLogGroupInfo lambda to 3 minutes

### DIFF
--- a/configuration/cloudformation/cwl-s3-export.template
+++ b/configuration/cloudformation/cwl-s3-export.template
@@ -267,7 +267,7 @@
                     }
                 },
                 "Runtime": "nodejs10.x",
-                "Timeout": "60"
+                "Timeout": "180"
             },
             "DependsOn": [
                 "LambdaGetCloudWatchLogGroupInfoExecutionPolicy"


### PR DESCRIPTION
Describing subscription filters on a log group may take longer than 1 minute, causing the stack to fail because the `CloudWatchLogGroupInfo` custom resource can't stabilise in time. 

Let's increase the timeout to on the `GetCloudWatchLogGroupInfo` function from 60s -> 180s (3 min).