### PR TITLE
Fixing fsevent issue while running install.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",
     "node-zip": "^1.1.1",
-    "onchange": "^1.1.0",
+    "onchange": "^7.1.0",
     "parallelshell": "^1.2.0",
     "process": "^0.11.1",
     "prompt": "^0.2.14",


### PR DESCRIPTION
There was an fsevent older version issue while running install.sh, fixed it by changes the dependent package upgrade.